### PR TITLE
Adding a tooltip to explain how duration is estimated

### DIFF
--- a/client/src/components/Tooltip.tsx
+++ b/client/src/components/Tooltip.tsx
@@ -1,0 +1,126 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { useTheme } from '../utils/ThemeContext';
+
+interface TooltipProps {
+  text: string;
+  children: React.ReactNode;
+  position?: 'top' | 'bottom' | 'left' | 'right';
+  width?: number;
+}
+
+const Tooltip: React.FC<TooltipProps> = ({ 
+  text, 
+  children, 
+  position = 'top',
+  width = 300
+}) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const { isDarkMode } = useTheme();
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
+  
+  useEffect(() => {
+    if (isVisible && tooltipRef.current && triggerRef.current) {
+      const trigger = triggerRef.current.getBoundingClientRect();
+      const tooltip = tooltipRef.current;
+      const tooltipRect = tooltip.getBoundingClientRect();
+      const padding = 8; // Space between trigger and tooltip
+      
+      // Reset position styles
+      tooltip.style.top = '';
+      tooltip.style.bottom = '';
+      tooltip.style.left = '';
+      tooltip.style.right = '';
+      tooltip.style.transform = '';
+      
+      // Position based on the specified direction
+      switch (position) {
+        case 'top':
+          tooltip.style.bottom = `${window.innerHeight - trigger.top + padding}px`;
+          tooltip.style.left = `${trigger.left + trigger.width / 2}px`;
+          tooltip.style.transform = 'translateX(-50%)';
+          
+          // Check if tooltip goes off the screen to the right
+          if (trigger.left + tooltipRect.width / 2 > window.innerWidth) {
+            tooltip.style.left = '';
+            tooltip.style.right = '10px';
+            tooltip.style.transform = '';
+          }
+          
+          // Check if tooltip goes off the screen to the left
+          if (trigger.left - tooltipRect.width / 2 < 0) {
+            tooltip.style.left = '10px';
+            tooltip.style.transform = '';
+          }
+          break;
+          
+        case 'bottom':
+          tooltip.style.top = `${trigger.bottom + padding + window.scrollY}px`;
+          tooltip.style.left = `${trigger.left + trigger.width / 2}px`;
+          tooltip.style.transform = 'translateX(-50%)';
+          
+          // Check if tooltip goes off the screen to the right
+          if (trigger.left + tooltipRect.width / 2 > window.innerWidth) {
+            tooltip.style.left = '';
+            tooltip.style.right = '10px';
+            tooltip.style.transform = '';
+          }
+          
+          // Check if tooltip goes off the screen to the left
+          if (trigger.left - tooltipRect.width / 2 < 0) {
+            tooltip.style.left = '10px';
+            tooltip.style.transform = '';
+          }
+          break;
+          
+        case 'left':
+          tooltip.style.right = `${window.innerWidth - trigger.left + padding}px`;
+          tooltip.style.top = `${trigger.top + trigger.height / 2 + window.scrollY}px`;
+          tooltip.style.transform = 'translateY(-50%)';
+          break;
+          
+        case 'right':
+          tooltip.style.left = `${trigger.right + padding}px`;
+          tooltip.style.top = `${trigger.top + trigger.height / 2 + window.scrollY}px`;
+          tooltip.style.transform = 'translateY(-50%)';
+          
+          // Check if tooltip goes off the screen to the right
+          if (trigger.right + tooltipRect.width > window.innerWidth) {
+            tooltip.style.left = '';
+            tooltip.style.right = `${window.innerWidth - trigger.left + padding}px`;
+          }
+          break;
+      }
+    }
+  }, [isVisible, position]);
+
+  return (
+    <div 
+      ref={triggerRef}
+      className="inline-block relative cursor-help"
+      onMouseEnter={() => setIsVisible(true)}
+      onMouseLeave={() => setIsVisible(false)}
+    >
+      {children}
+      
+      {isVisible && (
+        <div 
+          ref={tooltipRef}
+          className={`fixed z-50 p-4 rounded-lg shadow-lg text-sm animate-fade-in
+            ${isDarkMode 
+              ? 'bg-gray-800 text-gray-200 border border-gray-700' 
+              : 'bg-white text-gray-800 border border-gray-200'}`}
+          style={{ 
+            maxWidth: `${width}px`,
+            whiteSpace: 'normal',
+            pointerEvents: 'none'
+          }}
+        >
+          {text}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Tooltip;

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { useQuery, gql } from '@apollo/client';
 import StatsCard from '../components/StatsCard';
 import MigrationStatusBadge from '../components/MigrationStatusBadge';
+import Tooltip from '../components/Tooltip';
 import { MigrationState, Migration } from '../types';
 import { logger } from '../utils/logger';
 import debounce from 'lodash.debounce';
@@ -268,7 +269,18 @@ export const Dashboard: React.FC = () => {
           {migration.warningsCount || 0}
         </td>
         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">
-          {migration.duration ? `${Math.round(migration.duration / 1000 / 60)} mins` : '-'}
+          <Tooltip 
+            text="The duration is not a value directly reported by the migration process. Instead, it is estimated based on the time difference between when the migration was created and when the sync process last detected the status change for example, from In-Progress to Completed. Reducing the sync interval provides a more accurate duration estimate"
+            position="right"
+            width={350}
+          >
+            <span className="flex items-center cursor-help">
+              {migration.duration ? `${Math.round(migration.duration / 1000 / 60)} mins` : '-'}
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 ml-1 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+            </span>
+          </Tooltip>
         </td>
         <td className="px-6 py-4 whitespace-nowrap text-sm text-red-500 dark:text-red-400 truncate max-w-xs">
           {migration.failureReason || '-'}
@@ -560,11 +572,25 @@ export const Dashboard: React.FC = () => {
                   title="Warnings"
                   className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider"
                 />
-                <SortableHeader
-                  field="DURATION"
-                  title="Duration"
-                  className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider"
-                />
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                  <div className="flex items-center cursor-pointer" onClick={() => handleSort('DURATION')}>
+                    <Tooltip 
+                      text="The duration is not a value directly reported by the migration process. Instead, it is estimated based on the time difference between when the migration was created and when the sync process last detected the status change for example, from In-Progress to Completed. Reducing the sync interval provides a more accurate duration estimate"
+                      position="bottom"
+                      width={350}
+                    >
+                      <div className="flex items-center">
+                        <span>Duration</span>
+                        <span className={`ml-1 ${sortField === 'DURATION' ? 'opacity-100' : 'opacity-0 group-hover:opacity-50'}`}>
+                          {sortField === 'DURATION' ? (sortDirection === 'ASC' ? '↑' : '↓') : '↕'}
+                        </span>
+                        <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 ml-1 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        </svg>
+                      </div>
+                    </Tooltip>
+                  </div>
+                </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                   Failure Reason
                 </th>

--- a/client/src/pages/MigrationDetails.tsx
+++ b/client/src/pages/MigrationDetails.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, gql } from '@apollo/client';
 import MigrationStatusBadge from '../components/MigrationStatusBadge';
+import Tooltip from '../components/Tooltip';
 import { Migration } from '../types';
 import { logger } from '../utils/logger';
 
@@ -184,7 +185,20 @@ const MigrationDetails: React.FC = () => {
                     <p className="mt-1 text-sm text-gray-900 dark:text-white">{formattedDate}</p>
                   </div>
                   <div>
-                    <h4 className="text-xs font-medium text-gray-500 dark:text-gray-400">Duration</h4>
+                    <h4 className="text-xs font-medium text-gray-500 dark:text-gray-400 flex items-center">
+                      <Tooltip 
+                        text="The duration is not a value directly reported by the migration process. Instead, it is estimated based on the time difference between when the migration was created and when the sync process last detected the status change for example, from In-Progress to Completed. Reducing the sync interval provides a more accurate duration estimate"
+                        position="right"
+                        width={350}
+                      >
+                        <span className="flex items-center cursor-help">
+                          Duration
+                          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 ml-1 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                          </svg>
+                        </span>
+                      </Tooltip>
+                    </h4>
                     <p className="mt-1 text-sm text-gray-900 dark:text-white">
                       {migration.duration ? `${Math.round(migration.duration / 1000 / 60)} minutes` : 'Not completed'}
                     </p>

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -16,6 +16,15 @@ export default {
       },
       boxShadow: {
         'card': '0 2px 4px rgba(0, 0, 0, 0.05), 0 1px 2px rgba(0, 0, 0, 0.1)',
+      },
+      keyframes: {
+        fadeIn: {
+          '0%': { opacity: '0' },
+          '100%': { opacity: '1' },
+        }
+      },
+      animation: {
+        'fade-in': 'fadeIn 0.2s ease-in-out',
       }
     },
   },


### PR DESCRIPTION

Duration tooltip is shown in the title and values from the main dashboard
<img width="1122" height="521" alt="2025-08-06_12-05-40" src="https://github.com/user-attachments/assets/28ad0c1d-f6f2-461d-9026-3e52f4f1da8b" />

Also is shown in the Migration Details view.
<img width="827" height="448" alt="2025-08-06_13-05-52" src="https://github.com/user-attachments/assets/e7c6b08d-b7ba-4d64-aad8-bd770cc2ac66" />
